### PR TITLE
QAS-467-Fix-PushDataToReportPortal-setting

### DIFF
--- a/Sources/RPListener.swift
+++ b/Sources/RPListener.swift
@@ -85,101 +85,95 @@ public class RPListener: NSObject, XCTestObservation {
   }
     
   public func testSuiteWillStart(_ testSuite: XCTestSuite) {
-    guard self.configuration.shouldSendReport else {
-      return
-    }
-    guard
-      !testSuite.name.contains("All tests"),
-      !testSuite.name.contains("Selected tests") else
-    {
-      return
-    }
-    
-    queue.async {
-      do {
-        if testSuite.name.contains(".xctest") {
-          try self.reportingService.startRootSuite(testSuite)
-        } else {
-          try self.reportingService.startTestSuite(testSuite)
+    if self.configuration.shouldSendReport {
+      guard
+        !testSuite.name.contains("All tests"),
+        !testSuite.name.contains("Selected tests") else
+      {
+        return
+      }
+        
+      queue.async {
+        do {
+          if testSuite.name.contains(".xctest") {
+            try self.reportingService.startRootSuite(testSuite)
+          } else {
+            try self.reportingService.startTestSuite(testSuite)
+          }
+        } catch let error {
+          print(error)
         }
-      } catch let error {
-        print(error)
       }
     }
   }
     
   public func testCaseWillStart(_ testCase: XCTestCase) {
-    guard self.configuration.shouldSendReport else {
-      return
-    }
-    queue.async {
-      do {
-        try self.reportingService.startTest(testCase)
-      } catch let error {
-        print(error)
+    if self.configuration.shouldSendReport {
+      queue.async {
+        do {
+          try self.reportingService.startTest(testCase)
+        } catch let error {
+          print(error)
+        }
       }
     }
   }
     
   public func testCase(_ testCase: XCTestCase, didFailWithDescription description: String, inFile filePath: String?, atLine lineNumber: Int) {
-    guard self.configuration.shouldSendReport else {
-      return
-    }
-    queue.async {
-      do {
-        try self.reportingService.reportLog(level: "error", message: "Test '\(String(describing: testCase.name)))' failed on line \(lineNumber), \(description)")
-      } catch let error {
-        print(error)
+    if self.configuration.shouldSendReport {
+      queue.async {
+        do {
+          try self.reportingService.reportLog(level: "error", message: "Test '\(String(describing: testCase.name)))' failed on line \(lineNumber), \(description)")
+        } catch let error {
+          print(error)
+        }
       }
     }
   }
     
   public func testCaseDidFinish(_ testCase: XCTestCase) {
-    guard self.configuration.shouldSendReport else {
-      return
-    }
-    queue.async {
-      do {
-        try self.reportingService.finishTest(testCase)
-      } catch let error {
-        print(error)
+    if self.configuration.shouldSendReport {
+      queue.async {
+        do {
+          try self.reportingService.finishTest(testCase)
+        } catch let error {
+          print(error)
+        }
       }
     }
   }
     
   public func testSuiteDidFinish(_ testSuite: XCTestSuite) {
-    guard self.configuration.shouldSendReport else {
-      return
-    }
-    guard
-      !testSuite.name.contains("All tests"),
-      !testSuite.name.contains("Selected tests") else
-    {
-      return
-    }
+    if self.configuration.shouldSendReport {
+      guard
+        !testSuite.name.contains("All tests"),
+        !testSuite.name.contains("Selected tests") else
+      {
+        return
+      }
     
-    queue.async {
-      do {
-        if testSuite.name.contains(".xctest") {
-          try self.reportingService.finishRootSuite()
-        } else {
-          try self.reportingService.finishTestSuite()
+      queue.async {
+        do {
+          if testSuite.name.contains(".xctest") {
+            try self.reportingService.finishRootSuite()
+          } else {
+            try self.reportingService.finishTestSuite()
+          }
+        } catch let error {
+          print(error)
         }
-      } catch let error {
-        print(error)
       }
     }
   }
     
   public func testBundleDidFinish(_ testBundle: Bundle) {
-    guard self.configuration.shouldSendReport else {
-      return
-    }
-    queue.sync() {
-      do {
-        try self.reportingService.finishLaunch()
-      } catch let error {
-        print(error)
+    if self.configuration.shouldSendReport {
+      queue.sync() {
+        do {
+          try self.reportingService.finishLaunch()
+        } catch let error {
+         print(error)
+        }
       }
     }
   }

--- a/Sources/RPListener.swift
+++ b/Sources/RPListener.swift
@@ -13,6 +13,7 @@ public class RPListener: NSObject, XCTestObservation {
     
   private var reportingService: ReportingService!
   private let queue = DispatchQueue(label: "com.report_portal.reporting", qos: .utility)
+  private var configuration: AgentConfiguration!
     
   public override init() {
     super.init()
@@ -67,7 +68,7 @@ public class RPListener: NSObject, XCTestObservation {
   }
     
   public func testBundleWillStart(_ testBundle: Bundle) {
-    let configuration = readConfiguration(from: testBundle)
+    self.configuration = readConfiguration(from: testBundle)
     
     guard configuration.shouldSendReport else {
       print("Set 'YES' for 'PushTestDataToReportPortal' property in Info.plist if you want to put data to report portal")
@@ -84,6 +85,9 @@ public class RPListener: NSObject, XCTestObservation {
   }
     
   public func testSuiteWillStart(_ testSuite: XCTestSuite) {
+    guard self.configuration.shouldSendReport else {
+      return
+    }
     guard
       !testSuite.name.contains("All tests"),
       !testSuite.name.contains("Selected tests") else
@@ -105,6 +109,9 @@ public class RPListener: NSObject, XCTestObservation {
   }
     
   public func testCaseWillStart(_ testCase: XCTestCase) {
+    guard self.configuration.shouldSendReport else {
+      return
+    }
     queue.async {
       do {
         try self.reportingService.startTest(testCase)
@@ -115,6 +122,9 @@ public class RPListener: NSObject, XCTestObservation {
   }
     
   public func testCase(_ testCase: XCTestCase, didFailWithDescription description: String, inFile filePath: String?, atLine lineNumber: Int) {
+    guard self.configuration.shouldSendReport else {
+      return
+    }
     queue.async {
       do {
         try self.reportingService.reportLog(level: "error", message: "Test '\(String(describing: testCase.name)))' failed on line \(lineNumber), \(description)")
@@ -125,6 +135,9 @@ public class RPListener: NSObject, XCTestObservation {
   }
     
   public func testCaseDidFinish(_ testCase: XCTestCase) {
+    guard self.configuration.shouldSendReport else {
+      return
+    }
     queue.async {
       do {
         try self.reportingService.finishTest(testCase)
@@ -135,6 +148,9 @@ public class RPListener: NSObject, XCTestObservation {
   }
     
   public func testSuiteDidFinish(_ testSuite: XCTestSuite) {
+    guard self.configuration.shouldSendReport else {
+      return
+    }
     guard
       !testSuite.name.contains("All tests"),
       !testSuite.name.contains("Selected tests") else
@@ -156,6 +172,9 @@ public class RPListener: NSObject, XCTestObservation {
   }
     
   public func testBundleDidFinish(_ testBundle: Bundle) {
+    guard self.configuration.shouldSendReport else {
+      return
+    }
     queue.sync() {
       do {
         try self.reportingService.finishLaunch()

--- a/Sources/RPListener.swift
+++ b/Sources/RPListener.swift
@@ -86,13 +86,6 @@ public class RPListener: NSObject, XCTestObservation {
     
   public func testSuiteWillStart(_ testSuite: XCTestSuite) {
     if self.configuration.shouldSendReport {
-      guard
-        !testSuite.name.contains("All tests"),
-        !testSuite.name.contains("Selected tests") else
-      {
-        return
-      }
-        
       queue.async {
         do {
           if testSuite.name.contains(".xctest") {

--- a/Sources/RPListener.swift
+++ b/Sources/RPListener.swift
@@ -145,13 +145,6 @@ public class RPListener: NSObject, XCTestObservation {
     
   public func testSuiteDidFinish(_ testSuite: XCTestSuite) {
     if self.configuration.shouldSendReport {
-      guard
-        !testSuite.name.contains("All tests"),
-        !testSuite.name.contains("Selected tests") else
-      {
-        return
-      }
-    
       queue.async {
         do {
           if testSuite.name.contains(".xctest") {


### PR DESCRIPTION
JIRA: [QAS-467](https://headspace.atlassian.net/browse/QAS-467)

### What's in this PR?
Fix the PushTestDataToReportPortal setting work. If this parameter is set to NO, tests should run without sending data to the report portal.

### How to test?
Headspace UI Tests target: Set the **PushTestDataToReportPortal** setting into **NO**. Run any UI test. The test launch data doesn't appear in the [Report Portal](https://rp.epam.com/ui/#hsp-core/launches/all?page.page=1&page.size=50).
Set the **PushTestDataToReportPortal** setting into **YES**. Run any UI test. The test launch data appeared in the [Report Portal](https://rp.epam.com/ui/#hsp-core/launches/all?page.page=1&page.size=50).

### My code
RPListener.swift: at the beginning of each method a check for shouldSendReport is added. In case the value is a false method doesn't perform its code.