### PR TITLE
QAS-410-New-parameter-testPriority

### DIFF
--- a/Sources/Entities/AgentConfiguration.swift
+++ b/Sources/Entities/AgentConfiguration.swift
@@ -22,5 +22,6 @@ struct AgentConfiguration {
   let environment: String
   let buildVersion: String
   let testType: String
+  let testPriority: String
     
 }

--- a/Sources/RPListener.swift
+++ b/Sources/RPListener.swift
@@ -45,6 +45,7 @@ public class RPListener: NSObject, XCTestObservation {
     tags.append(testType.rawValue)
     tags.append(launchName)
     tags.append(buildVersion)
+    tags.append(testPriority.rawValue)
         
     var launchMode: LaunchMode = .default
     if let isDebug = bundleProperties["IsDebugLaunchMode"] as? Bool, isDebug == true {
@@ -171,10 +172,22 @@ public class RPListener: NSObject, XCTestObservation {
     case uiTest
   }
     
+  enum TestPriority: String {
+    case smoke
+    case mat
+    case regression
+  }
+    
   private(set) lazy var testType: TestType = {
     let type = ProcessInfo.processInfo.environment["TestType"] ?? ""
     let other = TestType(rawValue: type) ?? .uiTest
     
     return other
+  }()
+    
+  private(set) lazy var testPriority: TestPriority = {
+    let priority = ProcessInfo.processInfo.environment["TestPriority"] ?? ""
+
+    return TestPriority(rawValue: priority) ?? .regression
   }()
 }

--- a/Sources/RPListener.swift
+++ b/Sources/RPListener.swift
@@ -64,7 +64,8 @@ public class RPListener: NSObject, XCTestObservation {
       logDirectory: logDirectory,
       environment: environment,
       buildVersion: buildVersion,
-      testType: testType.rawValue
+      testType: testType.rawValue,
+      testPriority: testPriority.rawValue
       )
   }
     

--- a/Sources/ReportingService.swift
+++ b/Sources/ReportingService.swift
@@ -163,7 +163,7 @@ class ReportingService {
   }
     
   func getLaunchName() -> String {
-    return "iOS_" + configuration.launchName + "_" + configuration.testType + "_" + configuration.environment + "_" + configuration.buildVersion
+    return "iOS_" + configuration.launchName + "_" + configuration.testType + "_" + configuration.testPriority + "_" + configuration.environment + "_" + configuration.buildVersion
   }
 }
 

--- a/Sources/ReportingService.swift
+++ b/Sources/ReportingService.swift
@@ -163,7 +163,11 @@ class ReportingService {
   }
     
   func getLaunchName() -> String {
-    return "iOS_" + configuration.launchName + "_" + configuration.testType + "_" + configuration.testPriority + "_" + configuration.environment + "_" + configuration.buildVersion
+    var launchName = "iOS_" + configuration.launchName + "_" + configuration.testType
+    launchName += "_" + configuration.testPriority + "_" + configuration.environment
+    launchName += "_" + configuration.buildVersion
+   
+    return launchName
   }
 }
 


### PR DESCRIPTION
JIRA [QAS-410](https://headspace.atlassian.net/browse/QAS-410)

### What's in this PR?
Test plans will be organized accordingly to new rules: Smoke, MAT, and Regression. Therefore a new parameter - testPriority - was added. To distinguish test launches the same parameter was added into RP Adapter. The value of the parameter is added into the launch name and into tags. A testType parameter will be deleted on the next steps. 

### Now to test
Run any test plan from Headspace UI Tests target, and look to the Report Portal. New launch names and new tags should appear.

**My code**
 - [ ] Defensively handles and logs errors
- [ ]  Is free of retain cycles
- [ ]  Is not deeply nested (guard, etc.)
- [ ]  Is unit tested
- [ ]  Has UI test coverage
- [ ]  Properly enforces restrictions (private, final, etc.)
- [ ]  Does not force unwrap optionals