### PR TITLE
Build-version-was-deleted-from-the-launch-name

### DIFF
--- a/Sources/ReportingService.swift
+++ b/Sources/ReportingService.swift
@@ -165,7 +165,6 @@ class ReportingService {
   func getLaunchName() -> String {
     var launchName = "iOS_" + configuration.launchName + "_" + configuration.testType
     launchName += "_" + configuration.testPriority + "_" + configuration.environment
-    launchName += "_" + configuration.buildVersion
    
     return launchName
   }


### PR DESCRIPTION
**What's in this PR?**
Launch name was changed. A build version was deleted from it. 
As practice has shown, the build number in the lunch name does not carry a significant load, because we have the same version number in the tags. At the same time, if there is a build number in the lunch name, it becomes rather inconvenient to administer dashboards, since many widgets are tied to the lunch name. Therefore, as soon as the build number changes, you have to manually reconfigure a large number of widgets. It is not comfortable. It is also worth considering the fact that in future versions of the RP, developers plan to completely abandon the binding of widgets to the lunch name.
