### PR TITLE
QAS-587: fix decode error when launch is finished

### DIFF
--- a/ReportPortalAgent.xcodeproj/project.pbxproj
+++ b/ReportPortalAgent.xcodeproj/project.pbxproj
@@ -24,7 +24,7 @@
 		9203A3C5213730D400BFAF82 /* NameRules.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9203A3C4213730D400BFAF82 /* NameRules.swift */; };
 		92FEE06C212E925D00ADB1ED /* Item.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92FEE06B212E925D00ADB1ED /* Item.swift */; };
 		92FEE06E212E926400ADB1ED /* Launch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92FEE06D212E926400ADB1ED /* Launch.swift */; };
-		92FEE070212E943400ADB1ED /* Finish.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92FEE06F212E943400ADB1ED /* Finish.swift */; };
+		92FEE070212E943400ADB1ED /* FinishItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92FEE06F212E943400ADB1ED /* FinishItem.swift */; };
 		92FEE074212EA37200ADB1ED /* TestStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92FEE073212EA37200ADB1ED /* TestStatus.swift */; };
 		92FEE076212EA38600ADB1ED /* TestType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92FEE075212EA38600ADB1ED /* TestType.swift */; };
 		92FEE07C212ECB0800ADB1ED /* AgentConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92FEE07B212ECB0800ADB1ED /* AgentConfiguration.swift */; };
@@ -39,6 +39,7 @@
 		92FEE094212EEE2D00ADB1ED /* FinishItemEndPoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92FEE093212EEE2D00ADB1ED /* FinishItemEndPoint.swift */; };
 		92FEE096212EF30700ADB1ED /* StartItemEndPoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92FEE095212EF30700ADB1ED /* StartItemEndPoint.swift */; };
 		92FEE098212F028B00ADB1ED /* PostLogEndPoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92FEE097212F028B00ADB1ED /* PostLogEndPoint.swift */; };
+		DE4CC4E02405480700B5BC1A /* FinishLaunch.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE4CC4DF2405480700B5BC1A /* FinishLaunch.swift */; };
 		DEE32BA6238E6B4E0030CA36 /* FileService.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEE32BA5238E6B4E0030CA36 /* FileService.swift */; };
 /* End PBXBuildFile section */
 
@@ -99,7 +100,7 @@
 		9203A3C4213730D400BFAF82 /* NameRules.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NameRules.swift; sourceTree = "<group>"; };
 		92FEE06B212E925D00ADB1ED /* Item.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Item.swift; sourceTree = "<group>"; };
 		92FEE06D212E926400ADB1ED /* Launch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Launch.swift; sourceTree = "<group>"; };
-		92FEE06F212E943400ADB1ED /* Finish.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Finish.swift; sourceTree = "<group>"; };
+		92FEE06F212E943400ADB1ED /* FinishItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FinishItem.swift; sourceTree = "<group>"; };
 		92FEE073212EA37200ADB1ED /* TestStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestStatus.swift; sourceTree = "<group>"; };
 		92FEE075212EA38600ADB1ED /* TestType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestType.swift; sourceTree = "<group>"; };
 		92FEE07B212ECB0800ADB1ED /* AgentConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentConfiguration.swift; sourceTree = "<group>"; };
@@ -115,6 +116,7 @@
 		92FEE095212EF30700ADB1ED /* StartItemEndPoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartItemEndPoint.swift; sourceTree = "<group>"; };
 		92FEE097212F028B00ADB1ED /* PostLogEndPoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostLogEndPoint.swift; sourceTree = "<group>"; };
 		B298DF4C300965F413082F68 /* Pods_RPAgentSwiftXCTest.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RPAgentSwiftXCTest.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		DE4CC4DF2405480700B5BC1A /* FinishLaunch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FinishLaunch.swift; sourceTree = "<group>"; };
 		DEE32BA5238E6B4E0030CA36 /* FileService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileService.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -240,7 +242,8 @@
 				92FEE06D212E926400ADB1ED /* Launch.swift */,
 				92FEE07B212ECB0800ADB1ED /* AgentConfiguration.swift */,
 				9203A3C4213730D400BFAF82 /* NameRules.swift */,
-				92FEE06F212E943400ADB1ED /* Finish.swift */,
+				92FEE06F212E943400ADB1ED /* FinishItem.swift */,
+				DE4CC4DF2405480700B5BC1A /* FinishLaunch.swift */,
 			);
 			path = Entities;
 			sourceTree = "<group>";
@@ -464,9 +467,10 @@
 				92FEE08E212EEA0300ADB1ED /* TagHelper.swift in Sources */,
 				92FEE088212ECB7900ADB1ED /* UIDevice+ModelName.swift in Sources */,
 				368751BD1F5867200021B74D /* RPListener.swift in Sources */,
-				92FEE070212E943400ADB1ED /* Finish.swift in Sources */,
+				92FEE070212E943400ADB1ED /* FinishItem.swift in Sources */,
 				92FEE098212F028B00ADB1ED /* PostLogEndPoint.swift in Sources */,
 				92FEE08A212ECB7900ADB1ED /* AuthorizationPlugin.swift in Sources */,
+				DE4CC4E02405480700B5BC1A /* FinishLaunch.swift in Sources */,
 				92FEE086212ECB7900ADB1ED /* HTTPClient.swift in Sources */,
 				92FEE06C212E925D00ADB1ED /* Item.swift in Sources */,
 				9203A3872135882F00BFAF82 /* GetCurrentLaunchEndPoint.swift in Sources */,

--- a/Sources/Entities/FinishItem.swift
+++ b/Sources/Entities/FinishItem.swift
@@ -8,17 +8,17 @@
 
 import Foundation
 
-enum FinishKeys: String, CodingKey {
-  case msg = "msg"
+enum FinishItemKeys: String, CodingKey {
+  case msg = "message"
 }
 
 
-struct Finish: Decodable {
+struct FinishItem: Decodable {
   let message: String
-  
+
   init(from decoder: Decoder) throws {
-    let container = try decoder.container(keyedBy: FinishKeys.self)
+    let container = try decoder.container(keyedBy: FinishItemKeys.self)
     message = try container.decode(String.self, forKey: .msg)
   }
-  
+
 }

--- a/Sources/Entities/FinishLaunch.swift
+++ b/Sources/Entities/FinishLaunch.swift
@@ -1,0 +1,21 @@
+//
+//  FinishLaunch.swift
+//  RPAgentSwiftXCTest
+//
+//  Created by Natallia Mikuslakaya on 21-01-2020.
+//
+
+import Foundation
+
+enum FinishLaunchKeys: String, CodingKey {
+  case launchId = "id"
+}
+
+struct FinishLaunch: Decodable {
+  let launchId: String
+
+  init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: FinishLaunchKeys.self)
+    launchId = try container.decode(String.self, forKey: .launchId)
+  }
+}

--- a/Sources/ReportingService.swift
+++ b/Sources/ReportingService.swift
@@ -128,7 +128,7 @@ class ReportingService {
     
     let endPoint = FinishItemEndPoint(itemID: testID, status: testStatus)
     
-    let _: Result<Finish, Error> = self.httpClient.synchronousCallEndPoint(endPoint)
+    let _: Result<FinishItem, Error> = self.httpClient.synchronousCallEndPoint(endPoint)
   }
     
   func finishTestSuite() throws {
@@ -137,7 +137,7 @@ class ReportingService {
     }
     let endPoint = FinishItemEndPoint(itemID: testSuiteID, status: testSuiteStatus)
     
-    let _: Result<Finish, Error> = self.httpClient.synchronousCallEndPoint(endPoint)
+    let _: Result<FinishItem, Error> = self.httpClient.synchronousCallEndPoint(endPoint)
   }
     
   func finishRootSuite() throws {
@@ -146,7 +146,7 @@ class ReportingService {
     }
     let endPoint = FinishItemEndPoint(itemID: rootSuiteID, status: launchStatus)
    
-    let _: Result<Finish, Error> = self.httpClient.synchronousCallEndPoint(endPoint)
+    let _: Result<FinishItem, Error> = self.httpClient.synchronousCallEndPoint(endPoint)
   }
     
   func finishLaunch() throws {
@@ -159,7 +159,7 @@ class ReportingService {
     }
     let endPoint = FinishLaunchEndPoint(launchID: launchID, status: launchStatus)
     
-    let _: Result<Finish, Error> = self.httpClient.synchronousCallEndPoint(endPoint)
+    let _: Result<FinishLaunch, Error> = self.httpClient.synchronousCallEndPoint(endPoint)
   }
     
   func getLaunchName() -> String {


### PR DESCRIPTION
JIRA: [QAS-587](https://headspace.atlassian.net/browse/QAS-587)

**What's in this PR?**
A decoding error appears at the end of the test. This is because the structure of the response has been changed for launches. Thus, the Finish response element was divided into two parts: for elements and for launch.

