### PR TITLE
QAS-587: Exclude 'Selected tests' suite for local runs

### DIFF
--- a/Sources/Entities/FinishItem.swift
+++ b/Sources/Entities/FinishItem.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 enum FinishItemKeys: String, CodingKey {
-  case msg = "message"
+  case msg = "msg"
 }
 
 

--- a/Sources/Entities/FinishLaunch.swift
+++ b/Sources/Entities/FinishLaunch.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 enum FinishLaunchKeys: String, CodingKey {
-  case launchId = "id"
+  case launchId = "mgs"
 }
 
 struct FinishLaunch: Decodable {

--- a/Sources/RPListener.swift
+++ b/Sources/RPListener.swift
@@ -92,7 +92,7 @@ public class RPListener: NSObject, XCTestObservation {
         do {
           if testSuite.name.contains(".xctest") {
             try self.reportingService.startRootSuite(testSuite)
-          } else {
+          } else if !testSuite.name.contains("Selected tests") {
             try self.reportingService.startTestSuite(testSuite)
           }
         } catch let error {


### PR DESCRIPTION
JIRA: [QAS-587](https://headspace.atlassian.net/browse/QAS-587)

### What's in this PR?
When selected tests run while debugging an excessive suite with the name "Selected tests" appears and it can't be finished by the listener. Now the "Selected tests" suite isn't processed during finishing the launch.