### PR TITLE
QAS-587: using CIRCLECI parameter

### DIFF
--- a/Sources/RPListener.swift
+++ b/Sources/RPListener.swift
@@ -11,189 +11,189 @@ import XCTest
 
 public class RPListener: NSObject, XCTestObservation {
     
-  private var reportingService: ReportingService!
-  private let queue = DispatchQueue(label: "com.report_portal.reporting", qos: .utility)
-  private var configuration: AgentConfiguration!
-  private var publishData = false
+    private var reportingService: ReportingService!
+    private let queue = DispatchQueue(label: "com.report_portal.reporting", qos: .utility)
+    private var configuration: AgentConfiguration!
+    private var publishData = false
     
-  public override init() {
-    super.init()
-     
-    XCTestObservationCenter.shared.addTestObserver(self)
-  }
-  
-  private func readConfiguration(from testBundle: Bundle) -> AgentConfiguration {
-    guard
-      let bundlePath = testBundle.path(forResource: "Info", ofType: "plist"),
-      let bundleProperties = NSDictionary(contentsOfFile: bundlePath) as? [String: Any],
-      let shouldReport = bundleProperties["PushTestDataToReportPortal"] as? Bool,
-      let portalPath = bundleProperties["ReportPortalURL"] as? String,
-      let portalURL = URL(string: portalPath),
-      let projectName = bundleProperties["ReportPortalProjectName"] as? String,
-      let token = bundleProperties["ReportPortalToken"] as? String,
-      let shouldFinishLaunch = bundleProperties["IsFinalTestBundle"] as? Bool,
-      let launchName = bundleProperties["ReportPortalLaunchName"] as? String,
-      let logDirectory = bundleProperties["REMOTE_LOGGING_BASE_URL"] as? String,
-      let environment = bundleProperties["ENVIRONMENT_NAME"] as? String,
-      let buildVersion = bundleProperties["CFBundleShortVersionString"] as? String else
-    {
-      fatalError("Configure properties for report portal in the Info.plist")
-    }
-    var tags: [String] = []
-    if let tagString = bundleProperties["ReportPortalTags"] as? String {
-      tags = tagString.trimmingCharacters(in: CharacterSet.whitespacesAndNewlines).components(separatedBy: ",")
-    }
-    tags.append(testType.rawValue)
-    tags.append(launchName)
-    tags.append(buildVersion)
-    tags.append(testPriority.rawValue)
-        
-    var launchMode: LaunchMode = .default
-    if let isDebug = bundleProperties["IsDebugLaunchMode"] as? Bool, isDebug == true {
-      launchMode = .debug
-    }
-        
-    return AgentConfiguration(
-      reportPortalURL: portalURL,
-      projectName: projectName,
-      launchName: launchName,
-      shouldSendReport: shouldReport,
-      portalToken: token,
-      tags: tags,
-      shouldFinishLaunch: shouldFinishLaunch,
-      launchMode: launchMode,
-      logDirectory: logDirectory,
-      environment: environment,
-      buildVersion: buildVersion,
-      testType: testType.rawValue,
-      testPriority: testPriority.rawValue
-      )
-  }
-    
-  public func testBundleWillStart(_ testBundle: Bundle) {
-    self.configuration = readConfiguration(from: testBundle)
+    public override init() {
+        super.init()
 
-    if ProcessInfo.processInfo.environment["CIRCLECI"]! == "true" || configuration.shouldSendReport {
-        publishData = true
+        XCTestObservationCenter.shared.addTestObserver(self)
     }
-    
-    guard publishData else {
-      print("Set 'YES' for 'PushTestDataToReportPortal' property in Info.plist if you want to put data to report portal")
-      return
-    }
-    reportingService = ReportingService(configuration: configuration)
-    queue.async {
-      do {
-        try self.reportingService.startLaunch()
-      } catch let error {
-        print(error)
-      }
-    }
-  }
-    
-  public func testSuiteWillStart(_ testSuite: XCTestSuite) {
-    if publishData {
-      queue.async {
-        do {
-          if testSuite.name.contains(".xctest") {
-            try self.reportingService.startRootSuite(testSuite)
-          } else if !testSuite.name.contains("Selected tests") {
-            try self.reportingService.startTestSuite(testSuite)
-          }
-        } catch let error {
-          print(error)
-        }
-      }
-    }
-  }
-    
-  public func testCaseWillStart(_ testCase: XCTestCase) {
-    if publishData {
-      queue.async {
-        do {
-          try self.reportingService.startTest(testCase)
-        } catch let error {
-          print(error)
-        }
-      }
-    }
-  }
-    
-  public func testCase(_ testCase: XCTestCase, didFailWithDescription description: String, inFile filePath: String?, atLine lineNumber: Int) {
-    if publishData {
-      queue.async {
-        do {
-          try self.reportingService.reportLog(level: "error", message: "Test '\(String(describing: testCase.name)))' failed on line \(lineNumber), \(description)")
-        } catch let error {
-          print(error)
-        }
-      }
-    }
-  }
-    
-  public func testCaseDidFinish(_ testCase: XCTestCase) {
-    if publishData {
-      queue.async {
-        do {
-          try self.reportingService.finishTest(testCase)
-        } catch let error {
-          print(error)
-        }
-      }
-    }
-  }
-    
-  public func testSuiteDidFinish(_ testSuite: XCTestSuite) {
-    if publishData {
-      queue.async {
-        do {
-          if testSuite.name.contains(".xctest") {
-            try self.reportingService.finishRootSuite()
-          } else {
-            try self.reportingService.finishTestSuite()
-          }
-        } catch let error {
-          print(error)
-        }
-      }
-    }
-  }
-    
-  public func testBundleDidFinish(_ testBundle: Bundle) {
-    if publishData {
-      queue.sync() {
-        do {
-          try self.reportingService.finishLaunch()
-        } catch let error {
-         print(error)
-        }
-      }
-    }
-  }
-    
-  // MARK: - Environment
-    
-  enum TestType: String {
-    case e2eTest
-    case uiTest
-  }
-    
-  enum TestPriority: String {
-    case smoke
-    case mat
-    case regression
-  }
-    
-  private(set) lazy var testType: TestType = {
-    let type = ProcessInfo.processInfo.environment["TestType"] ?? ""
-    let other = TestType(rawValue: type) ?? .uiTest
-    
-    return other
-  }()
-    
-  private(set) lazy var testPriority: TestPriority = {
-    let priority = ProcessInfo.processInfo.environment["TestPriority"] ?? ""
 
-    return TestPriority(rawValue: priority) ?? .regression
-  }()
+    private func readConfiguration(from testBundle: Bundle) -> AgentConfiguration {
+        guard
+            let bundlePath = testBundle.path(forResource: "Info", ofType: "plist"),
+            let bundleProperties = NSDictionary(contentsOfFile: bundlePath) as? [String: Any],
+            let shouldReport = bundleProperties["PushTestDataToReportPortal"] as? Bool,
+            let portalPath = bundleProperties["ReportPortalURL"] as? String,
+            let portalURL = URL(string: portalPath),
+            let projectName = bundleProperties["ReportPortalProjectName"] as? String,
+            let token = bundleProperties["ReportPortalToken"] as? String,
+            let shouldFinishLaunch = bundleProperties["IsFinalTestBundle"] as? Bool,
+            let launchName = bundleProperties["ReportPortalLaunchName"] as? String,
+            let logDirectory = bundleProperties["REMOTE_LOGGING_BASE_URL"] as? String,
+            let environment = bundleProperties["ENVIRONMENT_NAME"] as? String,
+            let buildVersion = bundleProperties["CFBundleShortVersionString"] as? String else
+        {
+            fatalError("Configure properties for report portal in the Info.plist")
+        }
+        var tags: [String] = []
+        if let tagString = bundleProperties["ReportPortalTags"] as? String {
+            tags = tagString.trimmingCharacters(in: CharacterSet.whitespacesAndNewlines).components(separatedBy: ",")
+        }
+        tags.append(testType.rawValue)
+        tags.append(launchName)
+        tags.append(buildVersion)
+        tags.append(testPriority.rawValue)
+        
+        var launchMode: LaunchMode = .default
+        if let isDebug = bundleProperties["IsDebugLaunchMode"] as? Bool, isDebug == true {
+            launchMode = .debug
+        }
+        
+        return AgentConfiguration(
+            reportPortalURL: portalURL,
+            projectName: projectName,
+            launchName: launchName,
+            shouldSendReport: shouldReport,
+            portalToken: token,
+            tags: tags,
+            shouldFinishLaunch: shouldFinishLaunch,
+            launchMode: launchMode,
+            logDirectory: logDirectory,
+            environment: environment,
+            buildVersion: buildVersion,
+            testType: testType.rawValue,
+            testPriority: testPriority.rawValue
+        )
+    }
+    
+    public func testBundleWillStart(_ testBundle: Bundle) {
+        self.configuration = readConfiguration(from: testBundle)
+
+        if ProcessInfo.processInfo.environment["CIRCLECI"]! == "true" || configuration.shouldSendReport {
+            publishData = true
+        }
+
+        guard publishData else {
+            print("Set 'YES' for 'PushTestDataToReportPortal' property in Info.plist if you want to put data to report portal")
+            return
+        }
+        reportingService = ReportingService(configuration: configuration)
+        queue.async {
+            do {
+                try self.reportingService.startLaunch()
+            } catch let error {
+                print(error)
+            }
+        }
+    }
+    
+    public func testSuiteWillStart(_ testSuite: XCTestSuite) {
+      if publishData {
+        queue.async {
+          do {
+            if testSuite.name.contains(".xctest") {
+              try self.reportingService.startRootSuite(testSuite)
+            } else {
+              try self.reportingService.startTestSuite(testSuite)
+            }
+          } catch let error {
+            print(error)
+          }
+        }
+      }
+    }
+    
+    public func testCaseWillStart(_ testCase: XCTestCase) {
+        if publishData {
+            queue.async {
+                do {
+                    try self.reportingService.startTest(testCase)
+                } catch let error {
+                    print(error)
+                }
+            }
+        }
+    }
+    
+    public func testCase(_ testCase: XCTestCase, didFailWithDescription description: String, inFile filePath: String?, atLine lineNumber: Int) {
+        if publishData {
+            queue.async {
+                do {
+                    try self.reportingService.reportLog(level: "error", message: "Test '\(String(describing: testCase.name)))' failed on line \(lineNumber), \(description)")
+                } catch let error {
+                    print(error)
+                }
+            }
+        }
+    }
+    
+    public func testCaseDidFinish(_ testCase: XCTestCase) {
+        if publishData {
+            queue.async {
+                do {
+                    try self.reportingService.finishTest(testCase)
+                } catch let error {
+                    print(error)
+                }
+            }
+        }
+    }
+    
+    public func testSuiteDidFinish(_ testSuite: XCTestSuite) {
+        if publishData {
+            queue.async {
+                do {
+                    if testSuite.name.contains(".xctest") {
+                        try self.reportingService.finishRootSuite()
+                    } else if !testSuite.name.contains("Selected tests") {
+                        try self.reportingService.finishTestSuite()
+                    }
+                } catch let error {
+                    print(error)
+                }
+            }
+        }
+    }
+    
+    public func testBundleDidFinish(_ testBundle: Bundle) {
+        if publishData {
+            queue.sync() {
+                do {
+                    try self.reportingService.finishLaunch()
+                } catch let error {
+                    print(error)
+                }
+            }
+        }
+    }
+    
+    // MARK: - Environment
+    
+    enum TestType: String {
+        case e2eTest
+        case uiTest
+    }
+    
+    enum TestPriority: String {
+        case smoke
+        case mat
+        case regression
+    }
+    
+    private(set) lazy var testType: TestType = {
+        let type = ProcessInfo.processInfo.environment["TestType"] ?? ""
+        let other = TestType(rawValue: type) ?? .uiTest
+
+        return other
+    }()
+    
+    private(set) lazy var testPriority: TestPriority = {
+        let priority = ProcessInfo.processInfo.environment["TestPriority"] ?? ""
+
+        return TestPriority(rawValue: priority) ?? .regression
+    }()
 }

--- a/Sources/RPListener.swift
+++ b/Sources/RPListener.swift
@@ -10,190 +10,190 @@ import Foundation
 import XCTest
 
 public class RPListener: NSObject, XCTestObservation {
+  
+  private var reportingService: ReportingService!
+  private let queue = DispatchQueue(label: "com.report_portal.reporting", qos: .utility)
+  private var configuration: AgentConfiguration!
+  private var publishData = false
+  
+  public override init() {
+    super.init()
     
-    private var reportingService: ReportingService!
-    private let queue = DispatchQueue(label: "com.report_portal.reporting", qos: .utility)
-    private var configuration: AgentConfiguration!
-    private var publishData = false
-    
-    public override init() {
-        super.init()
-
-        XCTestObservationCenter.shared.addTestObserver(self)
+    XCTestObservationCenter.shared.addTestObserver(self)
+  }
+  
+  private func readConfiguration(from testBundle: Bundle) -> AgentConfiguration {
+    guard
+      let bundlePath = testBundle.path(forResource: "Info", ofType: "plist"),
+      let bundleProperties = NSDictionary(contentsOfFile: bundlePath) as? [String: Any],
+      let shouldReport = bundleProperties["PushTestDataToReportPortal"] as? Bool,
+      let portalPath = bundleProperties["ReportPortalURL"] as? String,
+      let portalURL = URL(string: portalPath),
+      let projectName = bundleProperties["ReportPortalProjectName"] as? String,
+      let token = bundleProperties["ReportPortalToken"] as? String,
+      let shouldFinishLaunch = bundleProperties["IsFinalTestBundle"] as? Bool,
+      let launchName = bundleProperties["ReportPortalLaunchName"] as? String,
+      let logDirectory = bundleProperties["REMOTE_LOGGING_BASE_URL"] as? String,
+      let environment = bundleProperties["ENVIRONMENT_NAME"] as? String,
+      let buildVersion = bundleProperties["CFBundleShortVersionString"] as? String else
+    {
+      fatalError("Configure properties for report portal in the Info.plist")
     }
-
-    private func readConfiguration(from testBundle: Bundle) -> AgentConfiguration {
-        guard
-            let bundlePath = testBundle.path(forResource: "Info", ofType: "plist"),
-            let bundleProperties = NSDictionary(contentsOfFile: bundlePath) as? [String: Any],
-            let shouldReport = bundleProperties["PushTestDataToReportPortal"] as? Bool,
-            let portalPath = bundleProperties["ReportPortalURL"] as? String,
-            let portalURL = URL(string: portalPath),
-            let projectName = bundleProperties["ReportPortalProjectName"] as? String,
-            let token = bundleProperties["ReportPortalToken"] as? String,
-            let shouldFinishLaunch = bundleProperties["IsFinalTestBundle"] as? Bool,
-            let launchName = bundleProperties["ReportPortalLaunchName"] as? String,
-            let logDirectory = bundleProperties["REMOTE_LOGGING_BASE_URL"] as? String,
-            let environment = bundleProperties["ENVIRONMENT_NAME"] as? String,
-            let buildVersion = bundleProperties["CFBundleShortVersionString"] as? String else
-        {
-            fatalError("Configure properties for report portal in the Info.plist")
-        }
-        var tags: [String] = []
-        if let tagString = bundleProperties["ReportPortalTags"] as? String {
-            tags = tagString.trimmingCharacters(in: CharacterSet.whitespacesAndNewlines).components(separatedBy: ",")
-        }
-        tags.append(testType.rawValue)
-        tags.append(launchName)
-        tags.append(buildVersion)
-        tags.append(testPriority.rawValue)
-        
-        var launchMode: LaunchMode = .default
-        if let isDebug = bundleProperties["IsDebugLaunchMode"] as? Bool, isDebug == true {
-            launchMode = .debug
-        }
-        
-        return AgentConfiguration(
-            reportPortalURL: portalURL,
-            projectName: projectName,
-            launchName: launchName,
-            shouldSendReport: shouldReport,
-            portalToken: token,
-            tags: tags,
-            shouldFinishLaunch: shouldFinishLaunch,
-            launchMode: launchMode,
-            logDirectory: logDirectory,
-            environment: environment,
-            buildVersion: buildVersion,
-            testType: testType.rawValue,
-            testPriority: testPriority.rawValue
-        )
+    var tags: [String] = []
+    if let tagString = bundleProperties["ReportPortalTags"] as? String {
+      tags = tagString.trimmingCharacters(in: CharacterSet.whitespacesAndNewlines).components(separatedBy: ",")
+    }
+    tags.append(testType.rawValue)
+    tags.append(launchName)
+    tags.append(buildVersion)
+    tags.append(testPriority.rawValue)
+    
+    var launchMode: LaunchMode = .default
+    if let isDebug = bundleProperties["IsDebugLaunchMode"] as? Bool, isDebug == true {
+      launchMode = .debug
     }
     
-    public func testBundleWillStart(_ testBundle: Bundle) {
-        self.configuration = readConfiguration(from: testBundle)
-
-        if ProcessInfo.processInfo.environment["CIRCLECI"]! == "true" || configuration.shouldSendReport {
-            publishData = true
-        }
-
-        guard publishData else {
-            print("Set 'YES' for 'PushTestDataToReportPortal' property in Info.plist if you want to put data to report portal")
-            return
-        }
-        reportingService = ReportingService(configuration: configuration)
-        queue.async {
-            do {
-                try self.reportingService.startLaunch()
-            } catch let error {
-                print(error)
-            }
-        }
+    return AgentConfiguration(
+      reportPortalURL: portalURL,
+      projectName: projectName,
+      launchName: launchName,
+      shouldSendReport: shouldReport,
+      portalToken: token,
+      tags: tags,
+      shouldFinishLaunch: shouldFinishLaunch,
+      launchMode: launchMode,
+      logDirectory: logDirectory,
+      environment: environment,
+      buildVersion: buildVersion,
+      testType: testType.rawValue,
+      testPriority: testPriority.rawValue
+    )
+  }
+  
+  public func testBundleWillStart(_ testBundle: Bundle) {
+    self.configuration = readConfiguration(from: testBundle)
+    
+    if ProcessInfo.processInfo.environment["CIRCLECI"]! == "true" || configuration.shouldSendReport {
+      publishData = true
     }
     
-    public func testSuiteWillStart(_ testSuite: XCTestSuite) {
-      if publishData {
-        queue.async {
-          do {
-            if testSuite.name.contains(".xctest") {
-              try self.reportingService.startRootSuite(testSuite)
-            } else {
-              try self.reportingService.startTestSuite(testSuite)
-            }
-          } catch let error {
-            print(error)
+    guard publishData else {
+      print("Set 'YES' for 'PushTestDataToReportPortal' property in Info.plist if you want to put data to report portal")
+      return
+    }
+    reportingService = ReportingService(configuration: configuration)
+    queue.async {
+      do {
+        try self.reportingService.startLaunch()
+      } catch let error {
+        print(error)
+      }
+    }
+  }
+  
+  public func testSuiteWillStart(_ testSuite: XCTestSuite) {
+    if publishData {
+      queue.async {
+        do {
+          if testSuite.name.contains(".xctest") {
+            try self.reportingService.startRootSuite(testSuite)
+          } else {
+            try self.reportingService.startTestSuite(testSuite)
           }
+        } catch let error {
+          print(error)
         }
       }
     }
-    
-    public func testCaseWillStart(_ testCase: XCTestCase) {
-        if publishData {
-            queue.async {
-                do {
-                    try self.reportingService.startTest(testCase)
-                } catch let error {
-                    print(error)
-                }
-            }
+  }
+  
+  public func testCaseWillStart(_ testCase: XCTestCase) {
+    if publishData {
+      queue.async {
+        do {
+          try self.reportingService.startTest(testCase)
+        } catch let error {
+          print(error)
         }
+      }
     }
-    
-    public func testCase(_ testCase: XCTestCase, didFailWithDescription description: String, inFile filePath: String?, atLine lineNumber: Int) {
-        if publishData {
-            queue.async {
-                do {
-                    try self.reportingService.reportLog(level: "error", message: "Test '\(String(describing: testCase.name)))' failed on line \(lineNumber), \(description)")
-                } catch let error {
-                    print(error)
-                }
-            }
+  }
+  
+  public func testCase(_ testCase: XCTestCase, didFailWithDescription description: String, inFile filePath: String?, atLine lineNumber: Int) {
+    if publishData {
+      queue.async {
+        do {
+          try self.reportingService.reportLog(level: "error", message: "Test '\(String(describing: testCase.name)))' failed on line \(lineNumber), \(description)")
+        } catch let error {
+          print(error)
         }
+      }
     }
-    
-    public func testCaseDidFinish(_ testCase: XCTestCase) {
-        if publishData {
-            queue.async {
-                do {
-                    try self.reportingService.finishTest(testCase)
-                } catch let error {
-                    print(error)
-                }
-            }
+  }
+  
+  public func testCaseDidFinish(_ testCase: XCTestCase) {
+    if publishData {
+      queue.async {
+        do {
+          try self.reportingService.finishTest(testCase)
+        } catch let error {
+          print(error)
         }
+      }
     }
-    
-    public func testSuiteDidFinish(_ testSuite: XCTestSuite) {
-        if publishData {
-            queue.async {
-                do {
-                    if testSuite.name.contains(".xctest") {
-                        try self.reportingService.finishRootSuite()
-                    } else if !testSuite.name.contains("Selected tests") {
-                        try self.reportingService.finishTestSuite()
-                    }
-                } catch let error {
-                    print(error)
-                }
-            }
+  }
+  
+  public func testSuiteDidFinish(_ testSuite: XCTestSuite) {
+    if publishData {
+      queue.async {
+        do {
+          if testSuite.name.contains(".xctest") {
+            try self.reportingService.finishRootSuite()
+          } else if !testSuite.name.contains("Selected tests") {
+            try self.reportingService.finishTestSuite()
+          }
+        } catch let error {
+          print(error)
         }
+      }
     }
-    
-    public func testBundleDidFinish(_ testBundle: Bundle) {
-        if publishData {
-            queue.sync() {
-                do {
-                    try self.reportingService.finishLaunch()
-                } catch let error {
-                    print(error)
-                }
-            }
+  }
+  
+  public func testBundleDidFinish(_ testBundle: Bundle) {
+    if publishData {
+      queue.sync() {
+        do {
+          try self.reportingService.finishLaunch()
+        } catch let error {
+          print(error)
         }
+      }
     }
+  }
+  
+  // MARK: - Environment
+  
+  enum TestType: String {
+    case e2eTest
+    case uiTest
+  }
+  
+  enum TestPriority: String {
+    case smoke
+    case mat
+    case regression
+  }
+  
+  private(set) lazy var testType: TestType = {
+    let type = ProcessInfo.processInfo.environment["TestType"] ?? ""
+    let other = TestType(rawValue: type) ?? .uiTest
     
-    // MARK: - Environment
+    return other
+  }()
+  
+  private(set) lazy var testPriority: TestPriority = {
+    let priority = ProcessInfo.processInfo.environment["TestPriority"] ?? ""
     
-    enum TestType: String {
-        case e2eTest
-        case uiTest
-    }
-    
-    enum TestPriority: String {
-        case smoke
-        case mat
-        case regression
-    }
-    
-    private(set) lazy var testType: TestType = {
-        let type = ProcessInfo.processInfo.environment["TestType"] ?? ""
-        let other = TestType(rawValue: type) ?? .uiTest
-
-        return other
-    }()
-    
-    private(set) lazy var testPriority: TestPriority = {
-        let priority = ProcessInfo.processInfo.environment["TestPriority"] ?? ""
-
-        return TestPriority(rawValue: priority) ?? .regression
-    }()
+    return TestPriority(rawValue: priority) ?? .regression
+  }()
 }


### PR DESCRIPTION
JIRA: [QAS-587](https://headspace.atlassian.net/browse/QAS-587)

### What's in this PR?
When selected tests run while debugging an excessive suite with the name "Selected tests" appears and it can't be finished by the listener. Now the "Selected tests" suite isn't processed during finishing the launch.
The logic of the pushing data to the Report Portal is changed. Now data can be sent if tests are run from CircleCI or the PushTestDataToReportPortal parameter is set to YES. By default, the PushTestDataToReportPortal parameter is set to NO in purpose to exclude local runs.