### PR TITLE
QAS-610: directory for logs was changed from Documents to Temp

### DIFF
--- a/Sources/Entities/FinishLaunch.swift
+++ b/Sources/Entities/FinishLaunch.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 enum FinishLaunchKeys: String, CodingKey {
-  case launchId = "mgs"
+  case launchId = "msg"
 }
 
 struct FinishLaunch: Decodable {

--- a/Sources/ReportingService.swift
+++ b/Sources/ReportingService.swift
@@ -17,7 +17,7 @@ class ReportingService {
     
   private let httpClient: HTTPClient
   private let configuration: AgentConfiguration
-  private var fileService: FileService?
+  private let fileService = FileService()
     
   private var launchID: String?
   private var testSuiteStatus = TestStatus.passed
@@ -31,7 +31,6 @@ class ReportingService {
     let baseURL = configuration.reportPortalURL.appendingPathComponent(configuration.projectName)
     httpClient = HTTPClient(baseURL: baseURL)
     httpClient.setPlugins([AuthorizationPlugin(token: configuration.portalToken)])
-    self.fileService = FileService(logsDirectory: configuration.logDirectory)
   }
     
   func startLaunch() throws {
@@ -107,7 +106,7 @@ class ReportingService {
         print(error)
      }
     
-     self.fileService!.createLogFile(withName: extractTestName(from: test))
+     fileService.createLogFile(withName: extractTestName(from: test))
    }
     
   func reportLog(level: String, message: String) throws {
@@ -123,8 +122,8 @@ class ReportingService {
       launchStatus = .failed
     }
     
-    try? reportLog(level: "info", message: fileService!.readLogFile(fileName: extractTestName(from: test)))
-    try? fileService!.deleteLogFile(withName: extractTestName(from: test))
+    try? reportLog(level: "info", message: fileService.readLogFile(fileName: extractTestName(from: test)))
+    try? fileService.deleteLogFile(withName: extractTestName(from: test))
     
     let endPoint = FinishItemEndPoint(itemID: testID, status: testStatus)
     

--- a/Sources/Utilities/FileService.swift
+++ b/Sources/Utilities/FileService.swift
@@ -14,26 +14,20 @@ final class FileService {
   private let logSubdirectoryName = "testLogs"
   private let initialLogText = "Test log: \r\n"
     
-  private var logsDirectoryFullName : String
   private var logDirectoryURL : URL
-    
-  init (logsDirectory: String) {
-    self.logsDirectoryFullName = logsDirectory
-    ///TODO: it is a temporary solution. Instead of .documentDirectory we need to use received path from self.logDirectory.
-    guard let directoryPath = fileManager.urls(for: .documentDirectory, in: .userDomainMask).first else {
-      fatalError("FileService init: Couldn't find document directory")
-    }
-    
-    self.logDirectoryURL = directoryPath.appendingPathComponent(logSubdirectoryName)
-   
-    if !fileManager.fileExists(atPath: self.logDirectoryURL.path) {
-      do {
-        try fileManager.createDirectory(atPath: self.logDirectoryURL.path, withIntermediateDirectories: true, attributes: nil)
-      } catch let error {
-        print("Error creating directory: \(error.localizedDescription)")
-      }
-    }
-  }
+
+   init () {
+     let directoryPath = fileManager.temporaryDirectory
+     self.logDirectoryURL = directoryPath.appendingPathComponent(logSubdirectoryName)
+
+     if !fileManager.fileExists(atPath: self.logDirectoryURL.path) {
+       do {
+         try fileManager.createDirectory(atPath: self.logDirectoryURL.path, withIntermediateDirectories: true, attributes: nil)
+       } catch let error {
+         print("Error creating directory: \(error.localizedDescription)")
+       }
+     }
+   }
     
   ///Return full path for particular file with given name
   func fullLogPathForFile(with fileName: String) -> URL {


### PR DESCRIPTION
JIRA [QAS-610](https://headspace.atlassian.net/browse/QAS-610)

### What's in this PR?
All test log files were saved in the user documents directory. It isn’t safe and doesn’t comply with the rules. Therefore, now logs will be saved in a temporary directory.