### PR TITLE
QAS-602: add tag with user name who run tests

### DIFF
--- a/Sources/Entities/AgentConfiguration.swift
+++ b/Sources/Entities/AgentConfiguration.swift
@@ -23,5 +23,6 @@ struct AgentConfiguration {
   let buildVersion: String
   let testType: String
   let testPriority: String
+  let testRunServerName: String
     
 }

--- a/Sources/RPListener.swift
+++ b/Sources/RPListener.swift
@@ -41,7 +41,9 @@ public class RPListener: NSObject, XCTestObservation {
       fatalError("Configure properties for report portal in the Info.plist")
     }
 
-    let currentServerName = getServerName()
+    //Determine user name/machine name which inits test run. Initially, the data looks like /Users/epamcontractor/Library/Developer/...
+    //We need to extract the second value, i.e. epamcontractor for example.
+    let currentServerName = String(ProcessInfo.processInfo.arguments[0].split(separator: "/")[1])
 
     var tags: [String] = []
     if let tagString = bundleProperties["ReportPortalTags"] as? String {
@@ -176,18 +178,6 @@ public class RPListener: NSObject, XCTestObservation {
         }
       }
     }
-  }
-
-  private func getServerName() -> String {
-    //Determine user name/machine name which inits test run. Initially, the data looks like /Users/epamcontractor/Library/Developer/...
-    //We need to extract the second value, i.e. epamcontractor for example.
-    let runnerPath = ProcessInfo.processInfo.arguments[0]
-    let startPosition = runnerPath.index(after: runnerPath.firstIndex(of: "/")!)
-    let substring = runnerPath.suffix(from: startPosition)
-    let startPosition1 = substring.index(after: substring.firstIndex(of: "/")!)
-    let substring1 = substring.suffix(from: startPosition1)
-    let endPosition = substring1.firstIndex(of: "/")!
-    return String(substring1.prefix(upTo: endPosition))
   }
 
   // MARK: - Environment

--- a/Sources/RPListener.swift
+++ b/Sources/RPListener.swift
@@ -175,13 +175,13 @@ public class RPListener: NSObject, XCTestObservation {
     }
   }
 
-    private func getServerName() -> String {
-        let runnerPath = ProcessInfo.processInfo.arguments[0]
-        let startPosition = runnerPath.firstIndex(of: "/")!
-        let substring = runnerPath.suffix(from: startPosition)
-        let endPosition = substring.firstIndex(of: "/")!
-        return String(substring.prefix(upTo: endPosition))
-    }
+  private func getServerName() -> String {
+    let runnerPath = ProcessInfo.processInfo.arguments[0]
+    let startPosition = runnerPath.firstIndex(of: "/")!
+    let substring = runnerPath.suffix(from: startPosition)
+    let endPosition = substring.firstIndex(of: "/")!
+    return String(substring.prefix(upTo: endPosition))
+  }
 
   // MARK: - Environment
 


### PR DESCRIPTION
JIRA: [QAS-602](https://headspace.atlassian.net/browse/QAS-602)

### What's in this PR?
Continuation of the task of filtering local test runs on the Report Portal.
This time it was decided to add a new tag - the name of the machine with which the test was run. If the name of the machine does not match what is indicated in the info.plist, then only then the PushTestDataToReportPortal parameter will be analyzed. By default, all tests that are launched from the distiller machine will be sent to the Portal regardless of the PushTestDataToReportPortal parameter.
I also added a new type of TestPriority - debug. It will be set in the event that it is not Smoke, MAT or Regression.