### PR TITLE
QAS-648: Attach screenshot for failed test

### DIFF
--- a/ReportPortalAgent.xcodeproj/project.pbxproj
+++ b/ReportPortalAgent.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		368751BD1F5867200021B74D /* RPListener.swift in Sources */ = {isa = PBXBuildFile; fileRef = 368751B61F5867200021B74D /* RPListener.swift */; };
 		368751BF1F5867200021B74D /* ReportingService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 368751B81F5867200021B74D /* ReportingService.swift */; };
+		56F18855244DE6000059C138 /* PostScreenshotEndPoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56F18854244DE6000059C138 /* PostScreenshotEndPoint.swift */; };
 		9203A3872135882F00BFAF82 /* GetCurrentLaunchEndPoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9203A3862135882F00BFAF82 /* GetCurrentLaunchEndPoint.swift */; };
 		9203A38F2135C20C00BFAF82 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9203A38E2135C20C00BFAF82 /* AppDelegate.swift */; };
 		9203A3912135C20C00BFAF82 /* SummatorViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9203A3902135C20C00BFAF82 /* SummatorViewController.swift */; };
@@ -81,6 +82,7 @@
 		368751E01F5964AA0021B74D /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		368751E21F596BC70021B74D /* ReportPortalAgent.podspec */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = ReportPortalAgent.podspec; sourceTree = "<group>"; };
 		368751E41F596E990021B74D /* LICENSE */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = LICENSE; sourceTree = "<group>"; };
+		56F18854244DE6000059C138 /* PostScreenshotEndPoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostScreenshotEndPoint.swift; sourceTree = "<group>"; };
 		9203A3862135882F00BFAF82 /* GetCurrentLaunchEndPoint.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GetCurrentLaunchEndPoint.swift; sourceTree = "<group>"; };
 		9203A38C2135C20C00BFAF82 /* Example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Example.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		9203A38E2135C20C00BFAF82 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -271,6 +273,7 @@
 				92FEE097212F028B00ADB1ED /* PostLogEndPoint.swift */,
 				92FEE091212EED3D00ADB1ED /* FinishLaunchEndPoint.swift */,
 				92FEE085212ECB7900ADB1ED /* EndPoint.swift */,
+				56F18854244DE6000059C138 /* PostScreenshotEndPoint.swift */,
 			);
 			path = EndPoints;
 			sourceTree = "<group>";
@@ -456,6 +459,7 @@
 				92FEE087212ECB7900ADB1ED /* TimeHelper.swift in Sources */,
 				368751BF1F5867200021B74D /* ReportingService.swift in Sources */,
 				9203A3C5213730D400BFAF82 /* NameRules.swift in Sources */,
+				56F18855244DE6000059C138 /* PostScreenshotEndPoint.swift in Sources */,
 				92FEE074212EA37200ADB1ED /* TestStatus.swift in Sources */,
 				9203A3C32137264000BFAF82 /* LaunchMode.swift in Sources */,
 				92FEE06E212E926400ADB1ED /* Launch.swift in Sources */,

--- a/ReportPortalAgent.xcodeproj/project.pbxproj
+++ b/ReportPortalAgent.xcodeproj/project.pbxproj
@@ -240,12 +240,12 @@
 		92FEE06A212E924B00ADB1ED /* Entities */ = {
 			isa = PBXGroup;
 			children = (
-				92FEE06B212E925D00ADB1ED /* Item.swift */,
-				92FEE06D212E926400ADB1ED /* Launch.swift */,
 				92FEE07B212ECB0800ADB1ED /* AgentConfiguration.swift */,
-				9203A3C4213730D400BFAF82 /* NameRules.swift */,
 				92FEE06F212E943400ADB1ED /* FinishItem.swift */,
 				DE4CC4DF2405480700B5BC1A /* FinishLaunch.swift */,
+				92FEE06B212E925D00ADB1ED /* Item.swift */,
+				92FEE06D212E926400ADB1ED /* Launch.swift */,
+				9203A3C4213730D400BFAF82 /* NameRules.swift */,
 			);
 			path = Entities;
 			sourceTree = "<group>";
@@ -254,11 +254,11 @@
 			isa = PBXGroup;
 			children = (
 				92FEE083212ECB7900ADB1ED /* AuthorizationPlugin.swift */,
-				92FEE07E212ECB7900ADB1ED /* HTTPClient.swift */,
-				92FEE07F212ECB7900ADB1ED /* TimeHelper.swift */,
-				92FEE08D212EEA0300ADB1ED /* TagHelper.swift */,
-				92FEE080212ECB7900ADB1ED /* UIDevice+ModelName.swift */,
 				DEE32BA5238E6B4E0030CA36 /* FileService.swift */,
+				92FEE07E212ECB7900ADB1ED /* HTTPClient.swift */,
+				92FEE08D212EEA0300ADB1ED /* TagHelper.swift */,
+				92FEE07F212ECB7900ADB1ED /* TimeHelper.swift */,
+				92FEE080212ECB7900ADB1ED /* UIDevice+ModelName.swift */,
 			);
 			path = Utilities;
 			sourceTree = "<group>";
@@ -266,14 +266,14 @@
 		92FEE081212ECB7900ADB1ED /* EndPoints */ = {
 			isa = PBXGroup;
 			children = (
-				9203A3862135882F00BFAF82 /* GetCurrentLaunchEndPoint.swift */,
-				92FEE084212ECB7900ADB1ED /* StartLaunchEndPoint.swift */,
-				92FEE095212EF30700ADB1ED /* StartItemEndPoint.swift */,
-				92FEE093212EEE2D00ADB1ED /* FinishItemEndPoint.swift */,
-				92FEE097212F028B00ADB1ED /* PostLogEndPoint.swift */,
-				92FEE091212EED3D00ADB1ED /* FinishLaunchEndPoint.swift */,
 				92FEE085212ECB7900ADB1ED /* EndPoint.swift */,
+				92FEE093212EEE2D00ADB1ED /* FinishItemEndPoint.swift */,
+				92FEE091212EED3D00ADB1ED /* FinishLaunchEndPoint.swift */,
+				9203A3862135882F00BFAF82 /* GetCurrentLaunchEndPoint.swift */,
+				92FEE097212F028B00ADB1ED /* PostLogEndPoint.swift */,
 				56F18854244DE6000059C138 /* PostScreenshotEndPoint.swift */,
+				92FEE095212EF30700ADB1ED /* StartItemEndPoint.swift */,
+				92FEE084212ECB7900ADB1ED /* StartLaunchEndPoint.swift */,
 			);
 			path = EndPoints;
 			sourceTree = "<group>";

--- a/Sources/EndPoints/EndPoint.swift
+++ b/Sources/EndPoints/EndPoint.swift
@@ -6,9 +6,12 @@
 //  Copyright © 2017 Oxagile. All rights reserved.
 //
 
+import  UIKit
+
 enum ParameterEncoding {
   case url
   case json
+  case multipart
 }
 
 enum HTTPMethod: String {
@@ -25,6 +28,8 @@ protocol EndPoint {
   var method: HTTPMethod { get }
   var relativePath: String { get }
   var parameters: [String: Any] { get }
+  var fileName: String { get }
+  var imageContent: UIImage { get }
   
 }
 
@@ -34,5 +39,6 @@ extension EndPoint {
   var encoding: ParameterEncoding { return .json }
   var method: HTTPMethod { return .get }
   var parameters: [String: Any] { return [:] }
-  
+  var fileName : String { return "" }
+  var imageContent: UIImage { return UIImage() }
 }

--- a/Sources/EndPoints/PostScreenshotEndPoint.swift
+++ b/Sources/EndPoints/PostScreenshotEndPoint.swift
@@ -1,0 +1,25 @@
+//
+//  PostScreenshotEndPoint.swift
+//  ReportPortalAgent
+//
+//  Created by EPAM Contractor  on 4/20/20.
+//  Copyright © 2020 Sergey Komarov. All rights reserved.
+//
+
+import Foundation
+
+struct PostScreenshotEndPoint: EndPoint {
+
+  let method: HTTPMethod = .post
+  let relativePath: String = "log"
+  let parameters: [String : Any]
+
+  init(itemID: String, fileName: String) {
+    parameters = [
+      "file" : ["name": fileName],
+      "item_id": itemID,
+      "time": TimeHelper.currentTimeAsString()
+    ]
+  }
+}
+

--- a/Sources/EndPoints/PostScreenshotEndPoint.swift
+++ b/Sources/EndPoints/PostScreenshotEndPoint.swift
@@ -7,19 +7,27 @@
 //
 
 import Foundation
+import UIKit
 
 struct PostScreenshotEndPoint: EndPoint {
 
   let method: HTTPMethod = .post
   let relativePath: String = "log"
   let parameters: [String : Any]
+  let encoding: ParameterEncoding = .multipart
+  let fileName: String
+  let imageContent: UIImage
 
-  init(itemID: String, fileName: String) {
+  init(itemID: String, fileName: String, content: UIImage, message: String) {
     parameters = [
       "file" : ["name": fileName],
       "item_id": itemID,
+      "level": "error",
+      "messge": message,
       "time": TimeHelper.currentTimeAsString()
     ]
+    self.imageContent = content
+    self.fileName = fileName
   }
 }
 

--- a/Sources/EndPoints/PostScreenshotEndPoint.swift
+++ b/Sources/EndPoints/PostScreenshotEndPoint.swift
@@ -23,7 +23,7 @@ struct PostScreenshotEndPoint: EndPoint {
       "file" : ["name": fileName],
       "item_id": itemID,
       "level": "error",
-      "messge": message,
+      "message": message,
       "time": TimeHelper.currentTimeAsString()
     ]
     self.imageContent = content

--- a/Sources/RPListener.swift
+++ b/Sources/RPListener.swift
@@ -132,7 +132,7 @@ public class RPListener: NSObject, XCTestObservation {
     if shouldPublishData {
       queue.async {
         do {
-          try self.reportingService.reportLog(level: "error", message: "Test '\(String(describing: testCase.name)))' failed on line \(lineNumber), \(description)")
+            try self.reportingService.reportLog(level: "error", message: "Test '\(String(describing: testCase.name)))' failed in file '\(filePath ?? "[]")' on line \(lineNumber), \(description)", test: testCase)
         } catch let error {
           print(error)
         }

--- a/Sources/ReportingService.swift
+++ b/Sources/ReportingService.swift
@@ -129,11 +129,11 @@ class ReportingService {
     }
 
     let testName = extractTestName(from: test)
-    let logFileName = testName+".log"
+    let logFileName = testName + ".log"
     try? reportLog(level: "info", message: fileService.readLogFile(fileName: logFileName))
     try? fileService.deleteFile(withName: logFileName)
 
-    let screenshotFileName = testName+".png"
+    let screenshotFileName = testName + ".png"
     if fileService.isFileExist(withName: screenshotFileName) {
       try? attachScreenshot(fileName: screenshotFileName)
       try? fileService.deleteFile(withName: screenshotFileName)

--- a/Sources/Utilities/FileService.swift
+++ b/Sources/Utilities/FileService.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import UIKit
 
 final class FileService {
   private let fileManager = FileManager()
@@ -49,6 +50,25 @@ final class FileService {
       throw FileServiceError.readFileError
     }
         
+  }
+
+  ///Read image file with given name and return its content
+  func readScreenshot(fileName: String) throws -> UIImage {
+
+    guard isFileExist(withName: fileName) else {
+      throw FileServiceError.fileDoesNotExistsError
+    }
+
+    do {
+      let fileContent = try UIImage(contentsOfFile: fullPathForFile(with: fileName).path)
+      guard let screenshot = fileContent else {
+        return UIImage()
+      }
+      return screenshot
+    } catch {
+      throw FileServiceError.readFileError
+    }
+
   }
     
   ///Delete file with given name

--- a/Sources/Utilities/FileService.swift
+++ b/Sources/Utilities/FileService.swift
@@ -10,7 +10,6 @@ import Foundation
 
 final class FileService {
   private let fileManager = FileManager()
-  private let fileExtention = ".log"
   private let logSubdirectoryName = "testLogs"
   private let initialLogText = "Test log: \r\n"
     
@@ -30,8 +29,8 @@ final class FileService {
    }
     
   ///Return full path for particular file with given name
-  func fullLogPathForFile(with fileName: String) -> URL {
-    let targetURL = self.logDirectoryURL.appendingPathComponent(fileName + fileExtention)
+  func fullPathForFile(with fileName: String) -> URL {
+    let targetURL = self.logDirectoryURL.appendingPathComponent(fileName)
         
     return targetURL
   }
@@ -39,12 +38,12 @@ final class FileService {
   ///Read log file with given name and return its content
   func readLogFile(fileName: String) throws -> String {
         
-    guard fileManager.fileExists(atPath: fullLogPathForFile(with: fileName).path) else {
+    guard isFileExist(withName: fileName) else {
         throw FileServiceError.fileDoesNotExistsError
     }
     
     do {
-      let fileContent = try String(contentsOfFile: fullLogPathForFile(with: fileName).path, encoding: String.Encoding.utf8)
+      let fileContent = try String(contentsOfFile: fullPathForFile(with: fileName).path, encoding: String.Encoding.utf8)
       return fileContent
     } catch {
       throw FileServiceError.readFileError
@@ -53,17 +52,19 @@ final class FileService {
   }
     
   ///Delete file with given name
-  func deleteLogFile(withName fileName: String) throws {
-    guard fileManager.fileExists(atPath: fullLogPathForFile(with: fileName).path) else{
-      return
+  func deleteFile(withName fileName: String) throws {
+    if isFileExist(withName: fileName) {
+      try? fileManager.removeItem(atPath: fullPathForFile(with: fileName).path)
     }
-        
-    try? fileManager.removeItem(atPath: fullLogPathForFile(with: fileName).path)
   }
     
   ///Create file with given name
   func createLogFile(withName fileName: String) {
-    fileManager.createFile(atPath: fullLogPathForFile(with: fileName).path, contents: initialLogText.data(using: String.Encoding.utf8))
+    fileManager.createFile(atPath: fullPathForFile(with: fileName).path, contents: initialLogText.data(using: String.Encoding.utf8))
+  }
+
+  func isFileExist(withName fileName: String) -> Bool {
+    return fileManager.fileExists(atPath: fullPathForFile(with: fileName).path)
   }
 }
 

--- a/Sources/Utilities/HTTPClient.swift
+++ b/Sources/Utilities/HTTPClient.swift
@@ -88,7 +88,6 @@ class HTTPClient {
     }
     print("***************** URL: \(request.url)")
     print("***************** Header: \(request.allHTTPHeaderFields) ")
-    print("***************** Body: \(String(data: request.httpBody as! Data, encoding: .utf8)!) ")
 
     utilityQueue.async {
       let task = URLSession.shared.dataTask(with: request as URLRequest) { (data: Data?, response: URLResponse?, error: Error?) in

--- a/Sources/Utilities/HTTPClient.swift
+++ b/Sources/Utilities/HTTPClient.swift
@@ -57,14 +57,13 @@ class HTTPClient {
 
     if endPoint.encoding == .multipart {
         let boundary = UUID().uuidString
-        let uuid = UUID().uuidString
         let CRLF = "\r\n"
         let fileName = endPoint.fileName + ".png"
         let formName = "file"
         let type = "image/png"
-        //request.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
+        request.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
 
-        guard let imageData = (endPoint.imageContent).pngData() else {
+        guard let imageData = UIImagePNGRepresentation(endPoint.imageContent) else {
             print("oops")
             return
         }
@@ -73,7 +72,7 @@ class HTTPClient {
         var body = data
         // file data //
         body.append(("--\(boundary)" + CRLF).data(using: .utf8)!)
-        body.append("Content-Disposition: form-data; name=\"formName\"; filename=\"\(fileName)\"\r\n".data(using: .utf8)!)
+        body.append("Content-Disposition: form-data; name=\"image_field\"; filename=\"\(fileName)\"\r\n".data(using: .utf8)!)
         body.append(("Content-Type: \(type)" + CRLF + CRLF).data(using: .utf8)!)
         body.append(imageData as Data)
         body.append(CRLF.data(using: .utf8)!)
@@ -87,7 +86,10 @@ class HTTPClient {
     plugins.forEach { (plugin) in
       plugin.processRequest(&request)
     }
-    print(request.url ?? "")
+    print("***************** URL: \(request.url)")
+    print("***************** Header: \(request.allHTTPHeaderFields) ")
+    print("***************** Body: \(String(data: request.httpBody as! Data, encoding: .utf8)!) ")
+
     utilityQueue.async {
       let task = URLSession.shared.dataTask(with: request as URLRequest) { (data: Data?, response: URLResponse?, error: Error?) in
         if let error = error {


### PR DESCRIPTION
JIRA: [QAS-648](https://headspace.atlassian.net/browse/QAS-648)

### What's in this PR?
It is convenient to have attached screenshots for quick and easier analysis of failed tests on the Report Portal.
This PR presents the second part - attaching the screenshot to a test in the Report Portal. Before attaching the screenshot, a check is made to see if there is a file with the expected name and extension in the specified location. After the file was attached it is deleted automatically.
The name of the screenshot file matches the name of the test and has the .png extension.