### PR TITLE
QAS-690: add the flaky test priority

### DIFF
--- a/Sources/RPListener.swift
+++ b/Sources/RPListener.swift
@@ -192,6 +192,7 @@ public class RPListener: NSObject, XCTestObservation {
     case mat
     case regression
     case debug
+    case flaky
   }
 
   private(set) lazy var testType: TestType = {


### PR DESCRIPTION
JIRA: [QAS-690](https://headspace.atlassian.net/browse/QAS-690)

### What's in this PR?
It is the second part. We started to run flaky tests as a separate run. Now they are marked as Regression. But it is not correct. We should separate the Flaky run from the Regression. Therefore, we need to create a new TestPriority - Flaky.
